### PR TITLE
code: updated `default_loader.sh` | style, formatting & refactoring

### DIFF
--- a/usr/share/regolith-look/default/root
+++ b/usr/share/regolith-look/default/root
@@ -13,8 +13,10 @@ regolith.look: default
 ! --------------------------------------------
 
 ! -- Specify either a complete file path to an image
+! -- and (optionally) options how to display the file
 
-regolith.wallpaper.file: 
+regolith.wallpaper.file:
+regolith.wallpaper.options:
 
 !-- *Or* specify a color
 

--- a/usr/share/regolith-look/default_loader.sh
+++ b/usr/share/regolith-look/default_loader.sh
@@ -1,61 +1,64 @@
-#!/bin/bash
+#! /bin/bash
 
 # This script updates the desktop UI configuration based on Xresources
-set -Eeu -o pipefail
+set -eE -u -o pipefail
 
 load_look() {
     # Set GNOME interface options from Xresources values if specifed by Xresources
-    GTK_THEME="$(xrescat gtk.theme_name)"
-    if [ -n  "$GTK_THEME" ]; then
-        gsettings set org.gnome.desktop.interface gtk-theme "$GTK_THEME"
+    GTK_THEME=$(xrescat gtk.theme_name || true)
+    if [[ -n ${GTK_THEME:-} ]]; then
+        gsettings set org.gnome.desktop.interface gtk-theme "${GTK_THEME}"
     fi
 
-    ICON_THEME="$(xrescat gtk.icon_theme_name)"
-    if [ -n  "$ICON_THEME" ]; then
-        gsettings set org.gnome.desktop.interface icon-theme "$ICON_THEME"
+    ICON_THEME=$(xrescat gtk.icon_theme_name || true)
+    if [[ -n ${ICON_THEME:-} ]]; then
+        gsettings set org.gnome.desktop.interface icon-theme "${ICON_THEME}"
     fi
 
-    WM_FONT="$(xrescat gtk.font_name)"
-    if [ -n  "$WM_FONT" ]; then
-        gsettings set org.gnome.desktop.interface font-name "$WM_FONT"
+    WM_FONT=$(xrescat gtk.font_name || true)
+    if [[ -n ${WM_FONT:-} ]]; then
+        gsettings set org.gnome.desktop.interface font-name "${WM_FONT}"
     fi
 
-    DOC_FONT="$(xrescat gtk.document_font_name)"
-    if [ -n  "$DOC_FONT" ]; then
-        gsettings set org.gnome.desktop.interface document-font-name "$DOC_FONT"
+    DOC_FONT=$(xrescat gtk.document_font_name || true)
+    if [[ -n ${DOC_FONT:-} ]]; then
+        gsettings set org.gnome.desktop.interface document-font-name "${DOC_FONT}"
     fi
 
-    MONO_FONT="$(xrescat gtk.monospace_font_name)"
-    if [ -n  "$MONO_FONT" ]; then
-        gsettings set org.gnome.desktop.interface monospace-font-name "$MONO_FONT"
+    MONO_FONT=$(xrescat gtk.monospace_font_name || true)
+    if [[ -n ${MONO_FONT:-} ]]; then
+        gsettings set org.gnome.desktop.interface monospace-font-name "${MONO_FONT}"
     fi
     
     # Set the wallpaper
-    WALLPAPER_FILE=$(xrescat regolith.wallpaper.file)
-    WALLPAPER_PRIMARY_COLOR=$(xrescat regolith.wallpaper.color.primary)
-    if [[ -f "$WALLPAPER_FILE" ]]; then
-        gsettings set org.gnome.desktop.background picture-uri "file://$(eval echo $WALLPAPER_FILE)"
-        gsettings set org.gnome.desktop.background picture-options wallpaper
-    elif [[ -n "$WALLPAPER_PRIMARY_COLOR" ]]; then
+    WALLPAPER_FILE=$(xrescat regolith.wallpaper.file || true)
+    WALLPAPER_FILE_OPTIONS=$(xrescat regolith.wallpaper.options || true)
+    WALLPAPER_PRIMARY_COLOR=$(xrescat regolith.wallpaper.color.primary || true)
+
+    if [[ -f ${WALLPAPER_FILE:-} ]]; then
+        gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE}"
+        gsettings set org.gnome.desktop.background picture-options "${WALLPAPER_FILE_OPTIONS:-wallpaper}"
+    elif [[ -n ${WALLPAPER_PRIMARY_COLOR:-} ]]; then
         gsettings set org.gnome.desktop.background picture-options none
         gsettings set org.gnome.desktop.background picture-uri none        
-        gsettings set org.gnome.desktop.background primary-color "$WALLPAPER_PRIMARY_COLOR"
+        gsettings set org.gnome.desktop.background primary-color "${WALLPAPER_PRIMARY_COLOR}"
 
-        WALLPAPER_SECONDARY_COLOR=$(xrescat regolith.wallpaper.color.secondary)
-        WALLPAPER_COLOR_SHADE_TYPE=$(xrescat regolith.wallpaper.color.shading.type)
+        WALLPAPER_SECONDARY_COLOR=$(xrescat regolith.wallpaper.color.secondary || true)
+        WALLPAPER_COLOR_SHADE_TYPE=$(xrescat regolith.wallpaper.color.shading.type || true)
 
-        if [[ -n "$WALLPAPER_SECONDARY_COLOR" ]] && [[ -n "$WALLPAPER_COLOR_SHADE_TYPE" ]]; then
-          gsettings set org.gnome.desktop.background secondary-color "$WALLPAPER_SECONDARY_COLOR"
-          gsettings set org.gnome.desktop.background color-shading-type "$WALLPAPER_COLOR_SHADE_TYPE"
+        if [[ -n ${WALLPAPER_SECONDARY_COLOR:-} ]] && [[ -n ${WALLPAPER_COLOR_SHADE_TYPE} ]]; then
+            gsettings set org.gnome.desktop.background secondary-color "${WALLPAPER_SECONDARY_COLOR}"
+            gsettings set org.gnome.desktop.background color-shading-type "${WALLPAPER_COLOR_SHADE_TYPE}"
         else
             gsettings set org.gnome.desktop.background color-shading-type 'solid'
         fi
     fi
 
     # Configure the gnome-terminal profile
-    if hash gnome-terminal 2>/dev/null; then # Check if gnome-terminal is on the path
-        UPDATE_TERM_FLAG=$(xrescat gnome.terminal.update true)
-        if [[ "$UPDATE_TERM_FLAG" == "true" && -f "/usr/share/regolith-ftue/regolith-init-term-profile" ]] ; then
+    if command -v gnome-terminal &>/dev/null; then # check if gnome-terminal is in ${PATH}
+        UPDATE_TERM_FLAG=$(xrescat gnome.terminal.update true || true)
+        if [[ "${UPDATE_TERM_FLAG:-}" == 'true' ]] && \
+           [[ -f '/usr/share/regolith-ftue/regolith-init-term-profile' ]] ; then
             /usr/share/regolith-ftue/regolith-init-term-profile
         fi
     fi


### PR DESCRIPTION
This PR does two things:

1. it refactors `default_loader.sh`
2. it adds an option for displaying the wallpaper file

The second point is self-explanatory. The first one consists of
making the script "true-Bash-like", which includes the use of
`[[ ... ]]`, parentheses around variables, pipe-errors masked inside
`$( ... )`, the removal of `eval echo ...`, and many small
non-idiomatic code snippets.

---

Tested on Ubuntu 22.04 with Regolith 2.0.