### PR TITLE
fix: regression in #2 + other possible bug

### DIFF
--- a/usr/share/regolith-look/default_loader.sh
+++ b/usr/share/regolith-look/default_loader.sh
@@ -37,7 +37,7 @@ load_look() {
     WALLPAPER_PRIMARY_COLOR=$(xrescat regolith.wallpaper.color.primary || true)
 
     if [[ -f ${WALLPAPER_FILE:-} ]]; then
-        gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE})"
+        gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE}"
         gsettings set org.gnome.desktop.background picture-options "${WALLPAPER_FILE_OPTIONS:-wallpaper}"
     elif [[ -n ${WALLPAPER_FILE_PRE_RESOLVED} ]]; then
         printf 'Path to wallpaper file ('%s') is invalid"' "${WALLPAPER_FILE_PRE_RESOLVED}" >&2

--- a/usr/share/regolith-look/default_loader.sh
+++ b/usr/share/regolith-look/default_loader.sh
@@ -39,7 +39,7 @@ load_look() {
     if [[ -f ${WALLPAPER_FILE:-} ]]; then
         gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE}"
         gsettings set org.gnome.desktop.background picture-options "${WALLPAPER_FILE_OPTIONS:-wallpaper}"
-    elif [[ -n ${WALLPAPER_FILE_PRE_RESOLVED} ]]; then
+    elif [[ ! -f ${WALLPAPER_FILE:-} ]] && [[ -n ${WALLPAPER_FILE_PRE_RESOLVED:-} ]]; then
         printf 'Path to wallpaper file ('%s') is invalid"' "${WALLPAPER_FILE_PRE_RESOLVED}" >&2
     elif [[ -n ${WALLPAPER_PRIMARY_COLOR:-} ]]; then
         gsettings set org.gnome.desktop.background picture-options none

--- a/usr/share/regolith-look/default_loader.sh
+++ b/usr/share/regolith-look/default_loader.sh
@@ -5,49 +5,49 @@ set -eE -u -o pipefail
 
 load_look() {
     # Set GNOME interface options from Xresources values if specifed by Xresources
-    GTK_THEME=$(xrescat gtk.theme_name || true)
+    GTK_THEME=$(xrescat gtk.theme_name || :)
     if [[ -n ${GTK_THEME:-} ]]; then
         gsettings set org.gnome.desktop.interface gtk-theme "${GTK_THEME}"
     fi
 
-    ICON_THEME=$(xrescat gtk.icon_theme_name || true)
+    ICON_THEME=$(xrescat gtk.icon_theme_name || :)
     if [[ -n ${ICON_THEME:-} ]]; then
         gsettings set org.gnome.desktop.interface icon-theme "${ICON_THEME}"
     fi
 
-    WM_FONT=$(xrescat gtk.font_name || true)
+    WM_FONT=$(xrescat gtk.font_name || :)
     if [[ -n ${WM_FONT:-} ]]; then
         gsettings set org.gnome.desktop.interface font-name "${WM_FONT}"
     fi
 
-    DOC_FONT=$(xrescat gtk.document_font_name || true)
+    DOC_FONT=$(xrescat gtk.document_font_name || :)
     if [[ -n ${DOC_FONT:-} ]]; then
         gsettings set org.gnome.desktop.interface document-font-name "${DOC_FONT}"
     fi
 
-    MONO_FONT=$(xrescat gtk.monospace_font_name || true)
+    MONO_FONT=$(xrescat gtk.monospace_font_name || :)
     if [[ -n ${MONO_FONT:-} ]]; then
         gsettings set org.gnome.desktop.interface monospace-font-name "${MONO_FONT}"
     fi
     
     # Set the wallpaper
-    WALLPAPER_FILE_PRE_RESOLVED=$(xrescat regolith.wallpaper.file || true)
-    WALLPAPER_FILE=$(realpath -e "${WALLPAPER_FILE_PRE_RESOLVED}" || true)
-    WALLPAPER_FILE_OPTIONS=$(xrescat regolith.wallpaper.options || true)
-    WALLPAPER_PRIMARY_COLOR=$(xrescat regolith.wallpaper.color.primary || true)
+    WALLPAPER_FILE=$(xrescat regolith.wallpaper.file || :)
+    WALLPAPER_FILE_RESOLVED=$(realpath -e "${WALLPAPER_FILE/#~/${HOME}}" 2>/dev/null || :)
+    WALLPAPER_FILE_OPTIONS=$(xrescat regolith.wallpaper.options || :)
+    WALLPAPER_PRIMARY_COLOR=$(xrescat regolith.wallpaper.color.primary || :)
 
-    if [[ -f ${WALLPAPER_FILE:-} ]]; then
-        gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE}"
+    if [[ -f ${WALLPAPER_FILE_RESOLVED:-} ]]; then
+        gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE_RESOLVED}"
         gsettings set org.gnome.desktop.background picture-options "${WALLPAPER_FILE_OPTIONS:-wallpaper}"
-    elif [[ ! -f ${WALLPAPER_FILE:-} ]] && [[ -n ${WALLPAPER_FILE_PRE_RESOLVED:-} ]]; then
-        printf 'Path to wallpaper file ('%s') is invalid"' "${WALLPAPER_FILE_PRE_RESOLVED}" >&2
+    elif [[ -n ${WALLPAPER_FILE:-} ]]; then
+        printf 'Path to wallpaper file ('%s') is invalid"' "${WALLPAPER_FILE}" >&2
     elif [[ -n ${WALLPAPER_PRIMARY_COLOR:-} ]]; then
         gsettings set org.gnome.desktop.background picture-options none
         gsettings set org.gnome.desktop.background picture-uri none        
         gsettings set org.gnome.desktop.background primary-color "${WALLPAPER_PRIMARY_COLOR}"
 
-        WALLPAPER_SECONDARY_COLOR=$(xrescat regolith.wallpaper.color.secondary || true)
-        WALLPAPER_COLOR_SHADE_TYPE=$(xrescat regolith.wallpaper.color.shading.type || true)
+        WALLPAPER_SECONDARY_COLOR=$(xrescat regolith.wallpaper.color.secondary || :)
+        WALLPAPER_COLOR_SHADE_TYPE=$(xrescat regolith.wallpaper.color.shading.type || :)
 
         if [[ -n ${WALLPAPER_SECONDARY_COLOR:-} ]] && [[ -n ${WALLPAPER_COLOR_SHADE_TYPE} ]]; then
             gsettings set org.gnome.desktop.background secondary-color "${WALLPAPER_SECONDARY_COLOR}"
@@ -59,7 +59,7 @@ load_look() {
 
     # Configure the gnome-terminal profile
     if command -v gnome-terminal &>/dev/null; then # check if gnome-terminal is in ${PATH}
-        UPDATE_TERM_FLAG=$(xrescat gnome.terminal.update || true)
+        UPDATE_TERM_FLAG=$(xrescat gnome.terminal.update || :)
         if [[ "${UPDATE_TERM_FLAG:-}" == 'true' ]] && \
            [[ -f '/usr/share/regolith-ftue/regolith-init-term-profile' ]] ; then
             /usr/share/regolith-ftue/regolith-init-term-profile

--- a/usr/share/regolith-look/default_loader.sh
+++ b/usr/share/regolith-look/default_loader.sh
@@ -31,13 +31,16 @@ load_look() {
     fi
     
     # Set the wallpaper
-    WALLPAPER_FILE=$(xrescat regolith.wallpaper.file || true)
+    WALLPAPER_FILE_PRE_RESOLVED=$(xrescat regolith.wallpaper.file || true)
+    WALLPAPER_FILE=$(realpath -e "${WALLPAPER_FILE_PRE_RESOLVED}" || true)
     WALLPAPER_FILE_OPTIONS=$(xrescat regolith.wallpaper.options || true)
     WALLPAPER_PRIMARY_COLOR=$(xrescat regolith.wallpaper.color.primary || true)
 
     if [[ -f ${WALLPAPER_FILE:-} ]]; then
-        gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE}"
+        gsettings set org.gnome.desktop.background picture-uri "file://${WALLPAPER_FILE})"
         gsettings set org.gnome.desktop.background picture-options "${WALLPAPER_FILE_OPTIONS:-wallpaper}"
+    elif [[ -n ${WALLPAPER_FILE_PRE_RESOLVED} ]]; then
+        printf 'Path to wallpaper file ('%s') is invalid"' "${WALLPAPER_FILE_PRE_RESOLVED}" >&2
     elif [[ -n ${WALLPAPER_PRIMARY_COLOR:-} ]]; then
         gsettings set org.gnome.desktop.background picture-options none
         gsettings set org.gnome.desktop.background picture-uri none        
@@ -56,7 +59,7 @@ load_look() {
 
     # Configure the gnome-terminal profile
     if command -v gnome-terminal &>/dev/null; then # check if gnome-terminal is in ${PATH}
-        UPDATE_TERM_FLAG=$(xrescat gnome.terminal.update true || true)
+        UPDATE_TERM_FLAG=$(xrescat gnome.terminal.update || true)
         if [[ "${UPDATE_TERM_FLAG:-}" == 'true' ]] && \
            [[ -f '/usr/share/regolith-ftue/regolith-init-term-profile' ]] ; then
             /usr/share/regolith-ftue/regolith-init-term-profile


### PR DESCRIPTION
So, it turns out https://github.com/regolith-linux/regolith-look-default/pull/2 introduced a small regression when it comes to resolving the path of the wallpaper set in Xresources. Now, one can use ~~variables and~~ especially `~` again. I used variable substitutions and `realpath -e` instead of `eval echo` as `realpath` is the canonical solution for this problem (looking at the man page: "Print the resolved absolute file name").

Moreover, `eval` is a potential security risk (as it would allow the user to execute arbitrary Bash code over `Xresources`; this is not a security concern right now I think because there is still no way for privilege escalation, but still, `eval` is not as nice as the new solution).

More information can be found in the commit message of [7bcaa19](https://github.com/regolith-linux/regolith-look-default/pull/3/commits/7bcaa19f5b451814cf8cab4e925d132ca2043418).

**Note**: Previously, the user could use arbitrary variables in the wallpaper file string. Due to `eval echo`, these would be expanded (correctly!). With the new approach, this does not work (because we do not expand variables anymore at all really). If this is not desired, please tell me, and I will revert to `eval echo`, but I have to admit, I strongly recommend not using `eval echo` for the reasons mentioned above.

---

The other possible bug was at the end of the script, when it comes to the GNOME terminal update routine. The command `xrescat gnome.terminal.update true` would always return `true`, no matter the second key (i.e. I could write `xrescat dawdmaldwmaldmkwamdkamdkaldw true` and it would return `true`). I have therefore deleted the second `true` after the first argument of
the call to `xrescat`.

---

I also replaced `|| true` with `|| :`. Information on that can be found in [7bcaa19](https://github.com/regolith-linux/regolith-look-default/pull/3/commits/7bcaa19f5b451814cf8cab4e925d132ca2043418) (this is just a minor detail, but when one has written as much Bash as I have, you want to do it right :D).

---

I'm sorry to have introduced the regression above. I thought I had tested it well, but as Edsger W. Disktra said: "Program testing can be used to show the presence of bugs, but never to show their absence!"