### PR TITLE
Set titlebar style settings

### DIFF
--- a/usr/share/regolith-look/default/i3-wm
+++ b/usr/share/regolith-look/default/i3-wm
@@ -1,8 +1,11 @@
-#define i3wm_window_border_size         2
-#define i3wm_floatingwindow_border_size 1
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          2
+#define i3wm_floatingwindow_border_size  1
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
+
 
 ilia.stylesheet: /usr/share/regolith-look/default/ilia.css
 


### PR DESCRIPTION
Set the titlebar style settings to 'pixel' to ensure titlebar is set correctly when switching to the look from one where they are set to 'normal'