### PR TITLE
Add support for org.gnome.desktop.interface color-scheme

### DIFF
--- a/usr/share/regolith-look/default_loader.sh
+++ b/usr/share/regolith-look/default_loader.sh
@@ -34,6 +34,11 @@ load_look() {
     if [[ -n ${MONO_FONT:-} ]]; then
         gsettings set org.gnome.desktop.interface monospace-font-name "${MONO_FONT}"
     fi
+
+    COLOR_SCHEME=$($RESOURCE_GETTER gtk.color_scheme || :)
+    if [[ -n ${COLOR_SCHEME:-} ]]; then
+        gsettings set org.gnome.desktop.interface color-scheme "${COLOR_SCHEME}"
+    fi
     
     # Set the wallpaper
     WALLPAPER_FILE=$($RESOURCE_GETTER regolith.wallpaper.file || :)

--- a/usr/share/regolith-look/default_loader.sh
+++ b/usr/share/regolith-look/default_loader.sh
@@ -37,7 +37,11 @@ load_look() {
 
     COLOR_SCHEME=$($RESOURCE_GETTER gtk.color_scheme || :)
     if [[ -n ${COLOR_SCHEME:-} ]]; then
+      # Ensure the color-scheme key is supported before setting its value
+      INTERFACE_KEYS=$(gsettings list-keys org.gnome.desktop.interface)
+      if [[ "${INTERFACE_KEYS}" =~ (^|$'\n')color-scheme($'\n'|$) ]]; then
         gsettings set org.gnome.desktop.interface color-scheme "${COLOR_SCHEME}"
+      fi
     fi
     
     # Set the wallpaper


### PR DESCRIPTION
This change allows looks to access the `org.gnome.desktop.interface color-scheme` setting.  Valid values are "default", "prefer-dark", and "prefer-light".

Firefox, e.g., looks at `org.gnome.desktop.interface color-scheme` when choosing a light or dark theme for its "System theme — auto" theme and "Website appearance" setting.